### PR TITLE
BSON::ObjectID doesn’t exist

### DIFF
--- a/lib/squealer/target.rb
+++ b/lib/squealer/target.rb
@@ -145,7 +145,7 @@ module Squealer
         case value
         when Array
           value.join(",")
-        when BSON::ObjectID
+        when BSON::ObjectId
           value.to_s
         else
           value


### PR DESCRIPTION
This is a quick fix to rename BSON::ObjectID to BSON::ObjectId
